### PR TITLE
fix(sec): upgrade org.apache.shiro:shiro-core to 1.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <properties>
         <testng.version>6.14.3</testng.version>
         <redisson.version>3.11.0</redisson.version>
-        <shiro-core.version>1.4.2</shiro-core.version>
+        <shiro-core.version>1.9.1</shiro-core.version>
 		<logback.version>1.2.3</logback.version>
     </properties>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.shiro:shiro-core 1.4.2
- [CVE-2021-41303](https://www.oscs1024.com/hd/CVE-2021-41303)


### What did I do？
Upgrade org.apache.shiro:shiro-core from 1.4.2 to 1.9.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS